### PR TITLE
Fix to the tab height (Issue #81500)

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -24,7 +24,6 @@ import 'tab_indicator.dart';
 import 'theme.dart';
 
 const double _kTabHeight = 46.0;
-const double _kTextAndIconTabHeight = 72.0;
 
 /// Defines how the bounds of the selected tab indicator are computed.
 ///
@@ -70,6 +69,7 @@ class Tab extends StatelessWidget implements PreferredSizeWidget{
     this.text,
     this.icon,
     this.iconMargin = const EdgeInsets.only(bottom: 10.0),
+    this.kTextAndIconTabHeight = 72,
     this.child,
   }) : assert(text != null || child != null || icon != null),
        assert(text == null || child == null),
@@ -95,6 +95,11 @@ class Tab extends StatelessWidget implements PreferredSizeWidget{
   /// Only useful when used in combination with [icon], and either one of
   /// [text] or [child] is non-null.
   final EdgeInsetsGeometry iconMargin;
+  
+  /// The widget height when there is an icon and text
+  /// 
+  /// useful when the combination of both overflows the defaut height
+  final double kTextAndIconTabHeight;
 
   Widget _buildLabelText() {
     return child ?? Text(text!, softWrap: false, overflow: TextOverflow.fade);
@@ -113,7 +118,7 @@ class Tab extends StatelessWidget implements PreferredSizeWidget{
       height = _kTabHeight;
       label = icon!;
     } else {
-      height = _kTextAndIconTabHeight;
+      height = kTextAndIconTabHeight;
       label = Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -146,7 +151,7 @@ class Tab extends StatelessWidget implements PreferredSizeWidget{
   @override
   Size get preferredSize {
     if ((text != null || child != null) && icon != null)
-      return const Size.fromHeight(_kTextAndIconTabHeight);
+      return Size.fromHeight(kTextAndIconTabHeight);
     else
       return const Size.fromHeight(_kTabHeight);
   }


### PR DESCRIPTION
*This PR changes the tab bar height when there is an icon and a text from a constant value to an user input, fixing the overflow when the icon + child widgets height is greater than 72*

*This PR fixes #81500*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
